### PR TITLE
Add the ability to pass redirects via async function

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ that will generate:
 
 ### Redirects
 
-You can also add [redirects][netlify-redirects], as many as you like. You should pass in an array of objects with the redirection attributes. For example:
+You can also add [redirects][netlify-redirects], as many as you like. You should pass in an array of objects (or a function that returns the array) with the redirection attributes. For example:
 
 
 ```js

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -36,12 +36,12 @@ You should pass in a object with string keys (representing the paths) and an arr
 
 ## redirects
 
-- Type: `array`
+- Type: `array, function`
 - Default: `[]`
 
 Adds extra redirects.
 
-You should pass in an array of objects with the redirection attributes. The available attributes for each redirect are:
+You should pass in an array of objects (or a function that returns the array) with the redirection attributes. The available attributes for each redirect are:
 
 - **from** (required): the path you want to redirect.
 - **to** (required): the URL or path you want to redirect to.

--- a/example/nuxt.config.js
+++ b/example/nuxt.config.js
@@ -1,6 +1,37 @@
 const path = require('path')
 const pkg = require('./package')
 
+const demoRedirects = [
+  {
+    from: 'https://example.com/temp/*',
+    to: 'https://example.com/:splat*'
+  },
+  {
+    from: '/en/*',
+    to: '/en/404.html',
+    status: 404
+  },
+  {
+    from: '/articles',
+    to: '/posts/:tag/:id',
+    status: 301,
+    force: true,
+    query: {
+      id: ':id',
+      tag: ':tag',
+    }
+  },
+  {
+    from: '/china/*',
+    to: '/china/zh-cn/:splat',
+    status: 302,
+    conditions: {
+      Language: 'zh',
+      Country: 'cn,hk,tw',
+    }
+  }
+]
+
 module.exports = {
   mode: 'universal',
 
@@ -55,35 +86,12 @@ module.exports = {
     }
   },
   netlify: {
-    redirects: [
-      {
-        from: 'https://example.com/temp/*',
-        to: 'https://example.com/:splat*'
-      },
-      {
-        from: '/en/*',
-        to: '/en/404.html',
-        status: 404
-      },
-      {
-        from: '/articles',
-        to: '/posts/:tag/:id',
-        status: 301,
-        force: true,
-        query: {
-          id: ':id',
-          tag: ':tag',
-        }
-      },
-      {
-        from: '/china/*',
-        to: '/china/zh-cn/:splat',
-        status: 302,
-        conditions: {
-          Language: 'zh',
-          Country: 'cn,hk,tw',
-        }
-      }
-    ]
+    // redirects: demoRedirects,
+    async redirects() {
+      const getRedirects = () => new Promise(
+        resolve => setTimeout(resolve(demoRedirects), 500)
+      )
+      return await getRedirects()
+    }
   }
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -23,8 +23,8 @@ function nuxtOptimizedImages (moduleOptions) {
   // validate options
   if (typeof options.headers !== 'object') {
     logger.fatal('The `headers` property must be an object')
-  } else if (!Array.isArray(options.redirects)) {
-    logger.fatal('The `redirects` property must be an array')
+  } else if (!Array.isArray(options.redirects) && typeof options.redirects !== 'function') {
+    logger.fatal('The `redirects` property must be an array or function')
   } else if (typeof options.transformHeaders !== 'function') {
     logger.fatal('The `transformHeaders` property must be a function')
   }
@@ -44,7 +44,7 @@ function nuxtOptimizedImages (moduleOptions) {
     // generate redirects
     try {
       const redirectsPath = path.resolve(rootDir, generate.dir, '_redirects')
-      const redirectsContent = generateRedirects(options)
+      const redirectsContent = await generateRedirects(options)
       await createFile(redirectsPath, redirectsContent)
       logger.success('Generated /_redirects')
     } catch (error) {

--- a/lib/redirects.js
+++ b/lib/redirects.js
@@ -1,10 +1,11 @@
 const { FILE_COMMENT } = require('./constants')
-const { createRedirectContent } = require('./utils')
+const { createRedirectContent, promisifyRedirects } = require('./utils')
 
-module.exports = (options) => {
+module.exports = async (options) => {
   let content = FILE_COMMENT
+  const redirects = await promisifyRedirects(options.redirects)
 
-  options.redirects.forEach(r => {
+  redirects.forEach(r => {
     content += createRedirectContent(r)
   })
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -72,10 +72,38 @@ const createRedirectContent = r => {
   return `${content}\n`
 }
 
+/**
+ * Promisify the `options.redirects` option
+ * @remarks Borrowed from nuxt/common/utils
+ */
+function promisifyRedirects(fn) {
+  // If routes is an array
+  if (Array.isArray(fn)) {
+    return Promise.resolve(fn)
+  }
+  // If routes is a function expecting a callback
+  if (fn.length === 1) {
+    return new Promise((resolve, reject) => {
+      fn(function (err, routeParams) {
+        if (err) {
+          reject(err)
+        }
+        resolve(routeParams)
+      })
+    })
+  }
+  let promise = fn()
+  if (!promise || (!(promise instanceof Promise) && typeof promise.then !== 'function')) {
+    promise = Promise.resolve(promise)
+  }
+  return promise
+}
+
 module.exports = {
   createFile,
   createHeadersContent,
   appendHeaders,
   isUrl,
-  createRedirectContent
+  createRedirectContent,
+  promisifyRedirects
 }


### PR DESCRIPTION
The current implementation is fine for static, hardcoded redirects, but not suited for getting them from an external backend. To fix this, I used the same implementation used in nuxt-sitemap which lets us pass a function instead of an array, so that the module would download redirects data when running `generate`.
Resolves issue: https://github.com/juliomrqz/nuxt-netlify/issues/180

TODO:
- [ ] update english doc
- [ ] update spanish doc
- [ ] I updated example with function instead of array, not sure if we should keep it
