### PR TITLE
Add extend hook to modify options before generate

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -31,6 +31,8 @@ function nuxtOptimizedImages (moduleOptions) {
 
   // Generate headers and redirects in dist
   this.nuxt.hook('generate:done', async () => {
+    await this.nuxt.callHook('netlify:extend', options)
+
     // generate headers
     try {
       const headersPath = path.resolve(rootDir, generate.dir, '_headers')


### PR DESCRIPTION
This allows modifying options before the generation starts and can be used inside a module. It can solve #239 since #210 has not been accepted yet.

```js
// nuxt.config.js

module.exports = {
  modules: [
    '~/modules/netlify.js'
  ]
}
```

```js
// modules/netlify.js

module.exports = function() {
  this.nuxt.hook('netlify:extend', async options => {
    const resp = await fetch('https://my.api/redirects.json')
    const data = resp.json()

    options.redirects.push(...data)
  })
}
```